### PR TITLE
Defend constants from runtime changes.

### DIFF
--- a/lib/paint.rb
+++ b/lib/paint.rb
@@ -7,7 +7,7 @@ module Paint
   autoload :RGB_COLORS_ANSI, 'paint/rgb_colors_ansi'
 
   # Important purpose
-  NOTHING = "\033[0m"
+  NOTHING = "\033[0m".freeze
 
   # Basic colors (often, the color differs when using the bright effect)
   # Final color will be 30 + value for foreground and 40 + value for background
@@ -21,7 +21,7 @@ module Paint
     :cyan    => 6,
     :white   => 7,
     :default => 9,
-  }
+  }.freeze
 
   # Terminal effects - most of them are not supported ;)
   # See http://en.wikipedia.org/wiki/ANSI_escape_code
@@ -52,33 +52,33 @@ module Paint
     :overline      => 53,
     :frame_off     => 54, :encircle_off    => 54,
     :overline_off  => 55,
-  }
+  }.freeze
 
   # cache
   ANSI_COLORS_FOREGROUND = {
-    :black   => '30',
-    :red     => '31',
-    :green   => '32',
-    :yellow  => '33',
-    :blue    => '34',
-    :magenta => '35',
-    :cyan    => '36',
-    :white   => '37',
-    :default => '39',
-  }
+    :black   => 30,
+    :red     => 31,
+    :green   => 32,
+    :yellow  => 33,
+    :blue    => 34,
+    :magenta => 35,
+    :cyan    => 36,
+    :white   => 37,
+    :default => 39,
+  }.freeze
 
   # cache
   ANSI_COLORS_BACKGROUND = {
-    :black   => '40',
-    :red     => '41',
-    :green   => '42',
-    :yellow  => '43',
-    :blue    => '44',
-    :magenta => '45',
-    :cyan    => '46',
-    :white   => '47',
-    :default => '49',
-  }
+    :black   => 40,
+    :red     => 41,
+    :green   => 42,
+    :yellow  => 43,
+    :blue    => 44,
+    :magenta => 45,
+    :cyan    => 46,
+    :white   => 47,
+    :default => 49,
+  }.freeze
 
   class << self
     # Takes a string and color options and colorizes the string

--- a/lib/paint/rgb_colors_ansi.rb
+++ b/lib/paint/rgb_colors_ansi.rb
@@ -10,7 +10,7 @@ module Paint
     :magenta => [205,0,205],
     :cyan    => [0,205,205],
     :white   => [229,229,229],
-  }
+  }.each { |k, v| v.freeze }.freeze
 
   # A list of color names for standard bright ansi colors, needed for 16 color fallback mode
   # See http://en.wikipedia.org/wiki/ANSI_escape_code#Colors
@@ -23,5 +23,5 @@ module Paint
     :magenta => [255,0,255],
     :cyan    => [0,255,255],
     :white   => [255,255,255],
-  }
+  }.each { |k, v| v.freeze }.freeze
 end

--- a/lib/paint/version.rb
+++ b/lib/paint/version.rb
@@ -1,3 +1,3 @@
 module Paint
-  VERSION = '0.8.7'
+  VERSION = '0.8.7'.freeze
 end


### PR DESCRIPTION
Hello!
This small PR just freeze constants, to avoid some like:

``` ruby
Paint::NOTHING[0] = 'bla-bla'
```

:)
