### PR TITLE
Ensure passed in hex strings are not modified

### DIFF
--- a/lib/paint.rb
+++ b/lib/paint.rb
@@ -173,8 +173,8 @@ module Paint
     end
 
     # Creates 256-compatible color from a html-like color string
-    def hex(string, background = false)
-      string.tr! '#',''
+    def hex(source, background = false)
+      string = source.tr '#',''
       color_code = if string.size == 6
         string.each_char.each_slice(2).map{ |hex_color| hex_color.join.to_i(16) }
       else

--- a/spec/paint_spec.rb
+++ b/spec/paint_spec.rb
@@ -40,6 +40,12 @@ describe 'Paint.[]' do
       Paint['J-_-L', "#4183C4"].should == "\e[38;5;74mJ-_-L\e[0m"
     end
 
+    it 'does not alter the passed in color string object' do
+      source = '#FFFFFF'
+      Paint['J-_-L', source]
+      source.should == '#FFFFFF'
+    end
+
     it 'understands a non-hex string as rgb color name (rgb.txt) and use it as foreground color' do
       Paint['J-_-L', "medium purple"].should == "\e[38;5;141mJ-_-L\e[0m"
     end


### PR DESCRIPTION
Consider the following scenario:

```
> Swatch = Struct.new(:name, :color)
Swatch < Struct

> red = Swatch.new('Red', '#ff0000')
{
     :name => "Red",
    :color => "#ff0000"
}

> red.color
"#ff0000"

> puts Paint[red.name, red.color]
Red
nil

> red.color
"ff0000"
```

I had a similar use-case where I had a nice, colorful rake task that used an object's stored color to output a string before saving. I noticed the stored color value kept getting altered to something that no longer worked elsewhere.

A work-around is to do:

```
puts Paint[red.name, "#{red.color}"]
```

But it just seems nicer to not modify passed in objects.

P.S. This is one of my favorite gems!