### PR TITLE
Fix nested substitutions

### DIFF
--- a/lib/paint.rb
+++ b/lib/paint.rb
@@ -27,7 +27,7 @@ module Paint
         substitutions.each{ |key, value|
           string.gsub!(
             "%{#{key}}",
-            (value.is_a?(Array) ? self%[value, current_color] : value.to_s)
+            (value.is_a?(Array) ? self.%(value, current_color) : value.to_s)
           )
         }
       end

--- a/lib/paint/version.rb
+++ b/lib/paint/version.rb
@@ -1,3 +1,3 @@
 module Paint
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end

--- a/spec/paint_spec.rb
+++ b/spec/paint_spec.rb
@@ -122,11 +122,11 @@ describe 'Paint.[]' do
     end
 
     it 'will work with arbitrary nesting and produce optimized escape sequences' do
-      Paint%['first level - %{second} - first level', :yellow, second:
+      (Paint%['first level - %{second} - first level', :yellow, second:
         ['second level - %{third} - second level', :red, third:
           ['third level', :green]
         ]
-      ].should == "\e[33mfirst level - \e[31msecond level - \e[32mthird level\e[31m - second level\e[33m - first level\e[0m"
+      ]).should == "\e[33mfirst level - \e[31msecond level - \e[32mthird level\e[31m - second level\e[33m - first level\e[0m"
     end
   end
 end


### PR DESCRIPTION
Nested substitutions were inserting uninterpreted hashes into output strings, and the spec designed to catch it was falsely passing somehow. I don't know how or why that test was passing.

Fixes the spec, then fixes the recursive call to #% so it doesn't double-wrap the arguments array.

Before: 
```
# irb after "require 'paint'"
2.3.0 (main):0 > Paint%['Yellow string with a %{blue_text} in it', :yellow, blue_text: ["blue text", :blue]]
=> "\e[33mYellow string with a \e[m[\"blue text\", :blue]\e[0m in it\e[0m"
```

After:
```
2.3.0 (main):0 > Paint%['Yellow string with a %{blue_text} in it', :yellow, blue_text: ["blue text", :blue]]
=> "\e[33mYellow string with a \e[34mblue text\e[33m in it\e[0m"
```