### PR TITLE
Fix Gem.unzip deprecation warning and update outdated Gems

### DIFF
--- a/lib/paint/rgb_colors.rb
+++ b/lib/paint/rgb_colors.rb
@@ -2,7 +2,7 @@ module Paint
   # A list of color names, based on X11's rgb.txt
   RGB_COLORS =
     Marshal.load(
-      Gem.gunzip(
+      Gem::Util.gunzip(
         File.binread(
           File.dirname(__FILE__) + '/../../data/rgb_colors.marshal.gz'
         )

--- a/paint.gemspec
+++ b/paint.gemspec
@@ -34,9 +34,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.requirements = ['Windows: ansicon (https://github.com/adoxa/ansicon) or ConEmu (http://code.google.com/p/conemu-maximus5)']
   s.add_development_dependency 'rspec', '~> 3.2'
-  s.add_development_dependency 'rake', '~> 10.4'
+  s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'benchmark-ips', '~> 2.7'
-  s.add_development_dependency 'rainbow', '~> 2.1'
+  s.add_development_dependency 'rainbow', '~> 3.0'
   s.add_development_dependency 'term-ansicolor', '~> 1.4'
   s.add_development_dependency 'ansi', '~> 1.5'
   s.add_development_dependency 'hansi', '~> 0.2'


### PR DESCRIPTION
The generation of the `Paint::RGB_COLORS` constant uses the deprecated `Gem.unzip` method, which has been replaced by `Gem::Util.unzip` with the identical calling sequence.

Rake is now at 12.3.2 rather than 10.4.2 (`-> 10.4`). No problems observed after the update.

The Rainbow Gem has been updated from 2.2.2 to 3.0.0; if anything, it's very slightly *slower* than before. Its position in the _Comparison_ rankings in the benchmark results is unaffected.