### PR TITLE
Default to true color rather than 256 colors

### DIFF
--- a/lib/paint.rb
+++ b/lib/paint.rb
@@ -182,12 +182,10 @@ module Paint
         end
       else
         case ENV['TERM']
-        when /-256color$/, 'xterm'
-          256
         when /-color$/, 'rxvt'
           16
         else # optimistic default
-          256
+          TRUE_COLOR
         end
       end
     end


### PR DESCRIPTION
This brings Paint's actual behavior in line with its README.md file.

Previously, on operating systems other than Windows, Paint 2.0.3 defaulted to 256 colors. With this commit it defaults to 24bit color on those systems, even if the `$TERM` environment variable matches `/-256color$/`.

There is no reliable way to detect 24bit color support based on the `$TERM` variable, and many terminals that support 24bit color will still report as e.g. `xterm-256color`.

No changes were made to Paint's mode detection on Windows, because it never fell back to 256 colors there in the first place.

Here's the relevant section of README.md:
> [Starting with Paint 2.0, true color mode is the new default mode, since most major terminals now support 24bit colors.](https://github.com/janlelis/paint#paint-20--true-color-support)

I'd also be completely okay if you rejected this request and changed the README instead.

Thank you for this lovely (and speedy) gem. ✨